### PR TITLE
Skip host controller ID and support wide SCSI addressing

### DIFF
--- a/mounter.h
+++ b/mounter.h
@@ -32,6 +32,8 @@ struct MountStruct
 	BOOL cdBoot;
 	// Ignore RDBFF_LAST flag
 	BOOL ignoreLast;
+	// Host controller SCSI ID - set to 255 for non-SCSI controllers
+	UBYTE hostId;
 };
 
 APTR W_CreateIORequest(struct MsgPort *ioReplyPort, ULONG size, struct ExecBase *SysBase);


### PR DESCRIPTION
Add hostId field to MountStruct to track the host controller's SCSI ID and skip it during device enumeration to avoid self-targeting. If you are using this mounter on a non-SCSI system you should set hostId to any number higher than your highest possible unit number (e.g. 255)

Implement Phase V wide SCSI addressing scheme for target IDs and LUNs greater than 7, falling back to traditional addressing for compatibility.
Define HD_WIDESCSI constant for wide SCSI unit number calculation.

From the OS3.9 include devices/scsi_disk.h:
--------------------------- 8< ---------------------------------
  With the advent of wide SCSI the scheme above fails miserably.
  A new scheme was adopted by Phase V, who appear to be the only
  source of wide SCSI for the Amiga at this time. Thus their
  numbering system kludge is adopted here. When the ID or LUN is
  above 7 the new numbering scheme is used.

  Unit =
	Board * 10 * 1000 * 1000 +
	LUN   * 10 * 1000        +
	ID    * 10               +
	HD_WIDESCSI;
--------------------------- 8< ---------------------------------