### PR TITLE
Fixup TD_MOTOR request null pointer dereference

### DIFF
--- a/mounter.c
+++ b/mounter.c
@@ -1607,9 +1607,9 @@ next_lun:
 							}
 
 							// Disable motor after probing
-							md->request->iotd_Req.io_Command = TD_MOTOR;
-							md->request->iotd_Req.io_Length  = 0;
-							DoIO((struct IORequest*)md->request);
+							request->iotd_Req.io_Command = TD_MOTOR;
+							request->iotd_Req.io_Length  = 0;
+							DoIO((struct IORequest*)request);
 
 							CloseDevice((struct IORequest*)request);
 


### PR DESCRIPTION
md->request is not set unless GetGeometry succeeds, on error paths it can cause a null pointer dereference